### PR TITLE
タスク入力画面とアクティビティログを切り替えるタブを実装

### DIFF
--- a/src/component/App.tsx
+++ b/src/component/App.tsx
@@ -1,28 +1,12 @@
 import React, { useState, useEffect } from 'react';
 import axiosbase from 'axios';
-import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import CssBaseline from '@material-ui/core/CssBaseline';
-import Grid from '@material-ui/core/Grid';
 import Header from './Header';
-import Sidebar, { drawerWidth } from './Sidebar';
-import TodoInput from './TodoInput';
-import { TodoItemProps } from './TodoItem';
-import TodoCounter from './TodoCounter';
-import CheckBoxList from './CheckBoxList';
-
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    app: {
-      paddingLeft: drawerWidth
-    }
-  })
-);
+import TabContainer from './TabContainer';
+import Sidebar from './Sidebar';
 
 export default function App() {
-  const initialTasks = [{ title: 'タスクその1', checked: false }];
-  const [tasks, setTasks] = useState<TodoItemProps[]>(initialTasks);
   const [screenNames, setScreenNames] = useState<string[]>([]);
-  const classes = useStyles({});
 
   // constructor
   useEffect(() => {
@@ -41,44 +25,12 @@ export default function App() {
       .then(names => setScreenNames(names));
   }, []);
 
-  const addTodo = (title: string): void => {
-    if (title === '') {
-      return;
-    }
-
-    const newTask = { title: title, checked: false };
-    const newTasks = tasks.concat(newTask);
-
-    setTasks(newTasks);
-  };
-
-  const checkTodo = (taskId: number, checked: boolean): void => {
-    let checkedTodos = [...tasks];
-    checkedTodos[taskId].checked = checked;
-
-    setTasks(checkedTodos);
-  };
-
-  const clearCheckedTodo = (): void => {
-    const nonSelectedTodos = tasks.filter(task => task.checked === false);
-
-    setTasks(nonSelectedTodos);
-  };
-
   return (
     <>
       <CssBaseline />
       <Header />
       <Sidebar screenNames={screenNames} />
-      <Grid container className={classes.app}>
-        <Grid item xs={6}>
-          <TodoInput addTodo={addTodo} clearCheckedTodo={clearCheckedTodo} />
-          <CheckBoxList tasks={tasks} checkTodo={checkTodo} />
-        </Grid>
-        <Grid item xs={4}>
-          <TodoCounter count={tasks.length} />
-        </Grid>
-      </Grid>
+      <TabContainer />
     </>
   );
 }

--- a/src/component/TabContainer.tsx
+++ b/src/component/TabContainer.tsx
@@ -1,0 +1,62 @@
+import React, { useState } from 'react';
+import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
+import AppBar from '@material-ui/core/AppBar';
+import Tabs from '@material-ui/core/Tabs';
+import Tab from '@material-ui/core/Tab';
+import Typography from '@material-ui/core/Typography';
+import Box from '@material-ui/core/Box';
+import { drawerWidth } from './Sidebar';
+import TaskInputContainer from './TaskInputContainer';
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    tabContainer: {
+      paddingLeft: drawerWidth
+    }
+  })
+);
+
+export default function TabContainer() {
+  const [value, setValue] = useState<number>(0);
+  const classes = useStyles({});
+
+  return (
+    <div className={classes.tabContainer}>
+      <AppBar position="static" color="default">
+        {/*  value: アクティブなタブ , onChange: valueが変わったら呼ばれるcallback*/}
+        <Tabs
+          variant="standard"
+          indicatorColor="primary"
+          value={value}
+          onChange={(e, newValue) => setValue(newValue)}
+        >
+          <Tab label="タスク入力" />
+          <Tab label="アクティビティログ" />
+        </Tabs>
+      </AppBar>
+
+      <TabPanel value={value} index={0}>
+        <TaskInputContainer />
+      </TabPanel>
+
+      <TabPanel value={value} index={1}>
+        アクティビティログ(実装予定)
+      </TabPanel>
+    </div>
+  );
+}
+
+interface TabPanelProps {
+  children?: React.ReactNode;
+  index: number;
+  value: number;
+}
+
+function TabPanel(props: TabPanelProps) {
+  return (
+    <Typography component="div" hidden={props.value !== props.index}>
+      {/* p: padding property. pだけなら全方向のpadding. https://material-ui.com/system/spacing/#api */}
+      <Box p={3}>{props.children}</Box>
+    </Typography>
+  );
+}

--- a/src/component/TaskInputContainer.tsx
+++ b/src/component/TaskInputContainer.tsx
@@ -1,0 +1,47 @@
+import React, { useState } from 'react';
+import Grid from '@material-ui/core/Grid';
+import TodoInput from './TodoInput';
+import TodoCounter from './TodoCounter';
+import { TodoItemProps } from './TodoItem';
+import CheckBoxList from './CheckBoxList';
+
+export default function TaskInputContainer() {
+  const initialTasks = [{ title: 'タスクその1', checked: false }];
+  const [tasks, setTasks] = useState<TodoItemProps[]>(initialTasks);
+
+  const addTodo = (title: string): void => {
+    if (title === '') {
+      return;
+    }
+
+    const newTask = { title: title, checked: false };
+    const newTasks = tasks.concat(newTask);
+
+    setTasks(newTasks);
+  };
+
+  const checkTodo = (taskId: number, checked: boolean): void => {
+    let checkedTodos = [...tasks];
+    checkedTodos[taskId].checked = checked;
+
+    setTasks(checkedTodos);
+  };
+
+  const clearCheckedTodo = (): void => {
+    const nonSelectedTodos = tasks.filter(task => task.checked === false);
+
+    setTasks(nonSelectedTodos);
+  };
+
+  return (
+    <Grid container>
+      <Grid item xs={6}>
+        <TodoInput addTodo={addTodo} clearCheckedTodo={clearCheckedTodo} />
+        <CheckBoxList tasks={tasks} checkTodo={checkTodo} />
+      </Grid>
+      <Grid item xs={4}>
+        <TodoCounter count={tasks.length} />
+      </Grid>
+    </Grid>
+  );
+}


### PR DESCRIPTION
![tan](https://user-images.githubusercontent.com/39644776/62008157-29225180-b191-11e9-8bd5-f823780022e4.png)

これまでApp.tsxにおいていたtask関連のstateとメソッドをタスク入力画面を表す<TaskInputContainer>に引っ越し、タブでタスク入力画面とアクティビティログ画面を切り替えられるようにした。

タブの実装はMaterial UIの例だと無駄にごちゃごちゃと書きすぎているので最低限必要なように絞った。